### PR TITLE
Casting the dev_ptr to avoid pedantic compiler errors for arithmetic operation on void* pointers

### DIFF
--- a/cudarray/wrap/array_data.pyx
+++ b/cudarray/wrap/array_data.pyx
@@ -15,7 +15,7 @@ cdef class ArrayData:
         if owner is None:
             cudaCheck(cudaMalloc(&self.dev_ptr, self.nbytes))
         else:
-            self.dev_ptr = owner.dev_ptr + offset*dtype.itemsize
+            self.dev_ptr = (<char *> owner.dev_ptr) + offset*dtype.itemsize
         if np_data is not None:
             cudaCheck(cudaMemcpyAsync(self.dev_ptr, np.PyArray_DATA(np_data),
                                       self.nbytes, cudaMemcpyHostToDevice))


### PR DESCRIPTION
Casting the dev_ptr to avoid pedantic compiler errors for arithmetic on void* pointers.

Solving issue https://github.com/andersbll/cudarray/issues/18 