### PR TITLE
fixes error: ‘memcpy’ was not declared in this scope

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ LIBCUDARRAY_BUILD = $(BUILD_DIR)/$(LIBCUDARRAY)
 LIBCUDARRAY_INSTALL = $(INSTALL_PREFIX)/lib/$(LIBCUDARRAY)
 
 INCLUDES += $(foreach include_dir,$(INCLUDE_DIRS),-I$(include_dir))
-C_FLAGS += -O3 -fPIC -Wall -Wfatal-errors
+C_FLAGS += -O3 -fPIC -Wall -Wfatal-errors -D_FORCE_INLINES
 NVCC_FLAGS = $(CUDA_ARCH) -O3 --compiler-options '$(C_FLAGS)' \
              --ftz=true --prec-div=false -prec-sqrt=false --fmad=true
 LDFLAGS += $(foreach lib_dir,$(LIB_DIRS),-L$(lib_dir)) \


### PR DESCRIPTION
make
nvcc -gencode arch=compute_20,code=sm_20 -gencode arch=compute_20,code=compute_20 -gencode arch=compute_30,code=sm_30 -gencode arch=compute_30,code=compute_30 -gencode arch=compute_35,code=sm_35 -gencode arch=compute_35,code=compute_35 -O3 --compiler-options '-O3 -fPIC -Wall -Wfatal-errors' --ftz=true --prec-div=false -prec-sqrt=false --fmad=true -I./include -I/usr/local/cuda/include -c -o src/nnet/pool_b01.o src/nnet/pool_b01.cu
/usr/include/string.h: In function ‘void* __mempcpy_inline(void*, const void*, size_t)’:
/usr/include/string.h:652:42: error: ‘memcpy’ was not declared in this scope
   return (char *) memcpy (__dest, __src, __n) + __n;
                                          ^
compilation terminated due to -Wfatal-errors.
Makefile:78: recipe for target 'src/nnet/pool_b01.o' failed


https://github.com/tensorflow/tensorflow/issues/1346